### PR TITLE
Fix the method "add" in the document to "push"

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -49,7 +49,7 @@ pub struct Font<'a> {
 }
 
 impl<'a> Font<'a> {
-    /// Create a new `Font`.  Add glyphs with `add()`.
+    /// Create a new `Font`.  Add glyphs with `push()`.
     pub fn new() -> Self {
         Self::default()
     }


### PR DESCRIPTION
The "Font" document says to use "add()" method to add glyphs, but it looks like a mistake for "push()".